### PR TITLE
fix typo `aditional` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ const logger = pino({
         projectId: 1,
         projectKey: "REPLACE_ME",
         environment: "production",
-        // aditional options for airbrake
+        // additional options for airbrake
         performanceStats: false,
       },
     },


### PR DESCRIPTION
Fixes #

## Description of the changes

small typo found in a comment of the code example!

It was `aditional` corrected to `additional`
